### PR TITLE
Support new metalog interface

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -67,7 +67,7 @@ class Channel {
     const data = application.getStaticFile(filePath);
     if (data) {
       res.end(data);
-      application.logger.access(`${ip}\t${method}\t${url}`);
+      application.console.log(`${ip}\t${method}\t${url}`);
       return;
     }
     this.error(404);
@@ -93,7 +93,7 @@ class Channel {
     const status = http.STATUS_CODES[code];
     if (typeof err === 'number') err = undefined;
     const reason = err ? err.stack : status;
-    application.logger.error(`${ip}\t${method}\t${url}\t${code}\t${reason}`);
+    application.console.error(`${ip}\t${method}\t${url}\t${code}\t${reason}`);
     const { Error } = this.application;
     const message = err instanceof Error ? err.message : status;
     const error = { message, code };
@@ -165,7 +165,7 @@ class Channel {
       }
       const token = this.session ? this.session.token : 'anonymous';
       const record = `${ip}\t${token}\t${interfaceName}/${methodName}`;
-      application.logger.access(record);
+      application.console.log(record);
     } catch (err) {
       this.error(500, err, callId);
     } finally {

--- a/lib/server.js
+++ b/lib/server.js
@@ -125,7 +125,7 @@ class Server {
 
   async close() {
     this.server.close(err => {
-      if (err) this.application.logger.error(err.stack);
+      if (err) this.application.console.error(err);
     });
     if (this.channels.size === 0) {
       await timeout(SHORT_TIMEOUT);


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm run t`)
- [x] code is properly formatted (`npm run fmt`)
