### PR TITLE
Online

### DIFF
--- a/dist/metacom.js
+++ b/dist/metacom.js
@@ -4,6 +4,12 @@ const RECONNECT_TIMEOUT = 2 * 1000;
 
 const connections = new Set();
 
+window.addEventListener('online', () => {
+  for (const connection of connections) {
+    connection.open();
+  }
+});
+
 class MetacomError extends Error {
   constructor({ message, code }) {
     super(message);

--- a/dist/metacom.js
+++ b/dist/metacom.js
@@ -6,7 +6,7 @@ const connections = new Set();
 
 window.addEventListener('online', () => {
   for (const connection of connections) {
-    connection.open();
+    if (!connection.connected) connection.open();
   }
 });
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
