### PR TITLE
Add EventEmitter as Metacom class parent

### DIFF
--- a/dist/events.js
+++ b/dist/events.js
@@ -1,0 +1,33 @@
+export class EventEmitter {
+  constructor() {
+    this.events = new Map();
+  }
+
+  on(name, fn) {
+    const event = this.events.get(name);
+    if (event) event.add(fn);
+    else this.events.set(name, new Set([fn]));
+  }
+
+  emit(name, ...args) {
+    const event = this.events.get(name);
+    if (!event) return;
+    for (const fn of event.values()) {
+      fn(...args);
+    }
+  }
+
+  remove(name, fn) {
+    const event = this.events.get(name);
+    if (!event) return;
+    if (event.has(fn)) {
+      event.delete(fn);
+      return;
+    }
+  }
+
+  clear(name) {
+    if (name) this.events.delete(name);
+    else this.events.clear();
+  }
+}

--- a/dist/metacom.js
+++ b/dist/metacom.js
@@ -1,3 +1,5 @@
+import { EventEmitter } from './events.js';
+
 const CALL_TIMEOUT = 7 * 1000;
 const PING_INTERVAL = 60 * 1000;
 const RECONNECT_TIMEOUT = 2 * 1000;
@@ -35,8 +37,9 @@ class MetacomInterface {
   }
 }
 
-export class Metacom {
+export class Metacom extends EventEmitter {
   constructor(url, options = {}) {
+    super();
     this.url = url;
     this.socket = null;
     this.api = {};


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
