### PR TITLE
WIP: Metacom streams

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -50,6 +50,7 @@ class Channel {
     this.connection = connection;
     this.application = application;
     this.client = new Client(connection);
+    this.streams = new Map();
     this.session = null;
     return this.init();
   }
@@ -114,6 +115,10 @@ class Channel {
       this.connection.send('{}');
       return;
     }
+    if (data.startsWith('{"stream"')) {
+      this.stream(data);
+      return;
+    }
     let packet;
     try {
       packet = JSON.parse(data);
@@ -130,6 +135,36 @@ class Channel {
       return;
     }
     this.error(500, new Error('Packet structure error'));
+  }
+
+  stream(data) {
+    const chunkStart = data.indexOf('}') + 1;
+    const meta = data.substring(0, chunkStart);
+    const chunk = data.substring(chunkStart);
+    let packet;
+    try {
+      packet = JSON.parse(meta);
+    } catch (err) {
+      this.error(500, new Error('JSON parsing error'));
+      return;
+    }
+    const { stream, name, size, status } = packet.stream;
+    if (typeof stream !== 'number') {
+      this.error(500, new Error('Invalid stream metadata'));
+      return;
+    }
+    if (name) {
+      this.streams.set(stream, { name, size, chunks: [], received: 0 });
+      return;
+    }
+    const record = this.streams.get(stream);
+    if (status) {
+      this.streams.delete(stream);
+      this.application.console.log('end', record);
+      return;
+    }
+    record.chunks.push(chunk);
+    this.application.console.log('chunk', record);
   }
 
   async rpc(callId, interfaceName, methodName, args) {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
