### PR TITLE
Use metautil instead of metarhia/common

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,7 @@ const http = require('http');
 const https = require('https');
 const worker = require('worker_threads');
 
-const common = require('@metarhia/common');
+const metautil = require('metautil');
 const ws = require('ws');
 
 const { Semaphore } = require('./semaphore.js');
@@ -75,8 +75,8 @@ class Server {
     });
 
     if (this.balancer) {
-      const host = common.parseHost(req.headers.host);
-      const port = common.sample(this.config.ports);
+      const host = metautil.parseHost(req.headers.host);
+      const port = metautil.sample(this.config.ports);
       const { protocol } = this.config;
       channel.redirect(`${protocol}://${host}:${port}/`);
       return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,8 @@
     "@metarhia/common": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@metarhia/common/-/common-2.2.0.tgz",
-      "integrity": "sha512-yAq1FPk2ayLAlj3QGOCSjpN5yWYLD3zLtJWkBRjQUlastAlrLzEMzTmbjLCGzz+lwZSwvSNsGHBsO0C42IO8CQ=="
+      "integrity": "sha512-yAq1FPk2ayLAlj3QGOCSjpN5yWYLD3zLtJWkBRjQUlastAlrLzEMzTmbjLCGzz+lwZSwvSNsGHBsO0C42IO8CQ==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -1090,6 +1091,11 @@
         "tap-yaml": "^1.0.0",
         "yargs": "^15.3.1"
       }
+    },
+    "metautil": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/metautil/-/metautil-3.0.0.tgz",
+      "integrity": "sha512-MWZCkpbNDy5MNP+xVyn7AJVb+GreGL4c/KDtwXqK1AeX9L/Dyq58EKRElBpD7bih9/6xv5qNqccd53HACGkm6Q=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "node": "^12.9 || 14 || 15"
   },
   "dependencies": {
-    "@metarhia/common": "^2.2.0",
-    "ws": "^7.4.1"
+    "ws": "^7.4.1",
+    "metautil": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^7.15.0",


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
