### PR TITLE
Remove csp-patch for google-fonts support

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -20,11 +20,6 @@ const HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type',
-  'Content-Security-Policy': [
-    `default-src 'self' ws:`,
-    `style-src 'self' https://fonts.googleapis.com`,
-    `font-src 'self' https://fonts.gstatic.com`,
-  ].join('; '),
 };
 
 class Client {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
