### PR TITLE
Fix spelling in method: Channel.startSession

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -234,7 +234,7 @@ class Channel {
     }
   }
 
-  starSession() {
+  startSession() {
     const token = this.generateToken();
     const host = metautil.parseHost(this.req.headers.host);
     const cookie = `${TOKEN}=${token}; ${COOKIE_HOST}=${host}`;


### PR DESCRIPTION
Closes: https://github.com/metarhia/metacom/issues/125

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
