### PR TITLE
Don't inject Channel to Server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -8,7 +8,7 @@ const metautil = require('metautil');
 const ws = require('ws');
 
 const { Semaphore } = require('./semaphore.js');
-const { channels } = require('./channel.js');
+const { Channel, channels } = require('./channel.js');
 
 const SHUTDOWN_TIMEOUT = 5000;
 const SHORT_TIMEOUT = 500;
@@ -28,10 +28,9 @@ const receiveBody = async (req) => {
 };
 
 class Server {
-  constructor(config, { application, Channel }) {
+  constructor(config, application) {
     this.config = config;
     this.application = application;
-    this.Channel = Channel;
     const { host, balancer, protocol, ports, concurrency, queue } = config;
     this.semaphore = new Semaphore(concurrency, queue.size, queue.timeout);
     const { threadId } = worker;
@@ -54,7 +53,6 @@ class Server {
   }
 
   async listener(req, res) {
-    const { Channel } = this;
     let finished = false;
     const { url } = req;
     const channel = await new Channel(req, res, null, this.application);


### PR DESCRIPTION
This changes Server.constructor signature from
`(config, { Channel, application })` to `(config, application)`
so should be published with new version of impress

Refs: https://github.com/metarhia/impress/pull/1459