### PR TITLE
Compatibility with impress application api structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix error passing to client side
 - Call application.invoke to execute methods with schema validation
+- Don't pass context to `application.getMethod`
+- Now proc is a struct, not just method with injected context
 
 ## [1.3.1][] - 2021-02-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Fix error passing to client side
 - Call application.invoke to execute methods with schema validation
 - Don't pass context to `application.getMethod`
-- Now proc is a struct, not just method with injected context
+  - Pass context to application.invoke
+  - Now proc is a struct, not just method with injected context
 
 ## [1.3.1][] - 2021-02-09
 

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -204,7 +204,7 @@ class Channel {
         this.error(403, null, callId);
         return;
       }
-      const result = await application.invoke(proc, args, context);
+      const result = await application.invoke(context, proc, args);
       if (result instanceof Error) {
         this.error(result.code, result, callId);
         return;

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -204,7 +204,7 @@ class Channel {
         this.error(403, null, callId);
         return;
       }
-      const result = await application.invoke(proc, args);
+      const result = await application.invoke(proc, args, context);
       if (result instanceof Error) {
         this.error(result.code, result, callId);
         return;

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -195,7 +195,7 @@ class Channel {
     const [iname, ver = '*'] = interfaceName.split('.');
     try {
       const context = session ? session.context : { client };
-      const proc = application.getMethod(iname, ver, methodName, context);
+      const proc = application.getMethod(iname, ver, methodName);
       if (!proc) {
         this.error(404, null, callId);
         return;


### PR DESCRIPTION
Rework metacom to be compatible with impress latest changes https://github.com/metarhia/impress/pull/1477

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
