### PR TITLE
Fix Channel.prototype.error

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -143,7 +143,7 @@ class Channel {
     res.end();
   }
 
-  error(code, err, callId) {
+  error(code, err = null, callId) {
     const { req, res, connection, ip, application } = this;
     const { url, method } = req;
     const status = http.STATUS_CODES[code];


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
