### PR TITLE
Update metautil to 3.5.0, change `timeout` to `delay`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Update metautil to 3.5.0, change `await timeout` to `await delay`
+
 ## [1.5.1][] - 2021-02-19
 
 - Fix restore session for Channel

--- a/lib/server.js
+++ b/lib/server.js
@@ -127,10 +127,10 @@ class Server {
       if (err) this.application.console.error(err);
     });
     if (channels.size === 0) {
-      await metautil.timeout(SHORT_TIMEOUT);
+      await metautil.delay(SHORT_TIMEOUT);
       return;
     }
-    await metautil.timeout(SHUTDOWN_TIMEOUT);
+    await metautil.delay(SHUTDOWN_TIMEOUT);
     this.closeChannels();
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1071,9 +1071,9 @@
       }
     },
     "metautil": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/metautil/-/metautil-3.3.0.tgz",
-      "integrity": "sha512-Xyvq9Mv32qPhxDCPUbiTBAkduzQwI5JGSw2UhSdsM8FztQEjlbOARw8+9o4YceeFomWLcaWy7Px1qmHoWNxAwg=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/metautil/-/metautil-3.5.0.tgz",
+      "integrity": "sha512-njpdFfP5lXZTmuTaL+le9nP+xn3WBJ1fR0iTjKSg53DyGj5063okevs7PouikNEZNZWwJruVJX5anoYFimdb5w=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": "^12.9 || 14 || 15"
   },
   "dependencies": {
-    "metautil": "^3.3.0",
+    "metautil": "^3.5.0",
     "ws": "^7.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
