### PR TITLE
Remove channel from collection on connections close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Update metautil to 3.5.0, change `await timeout` to `await delay`
+- Remove channel from collection on connections close
 
 ## [1.5.1][] - 2021-02-19
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -114,7 +114,7 @@ class Server {
   }
 
   closeChannels() {
-    for (const [client, channel] of channels.entries()) {
+    for (const channel of channels.values()) {
       if (channel.connection) {
         channel.connection.terminate();
       } else {

--- a/lib/server.js
+++ b/lib/server.js
@@ -41,6 +41,10 @@ class Server {
       connection.on('message', (data) => {
         channel.message(data);
       });
+      connection.on('close', () => {
+        channels.delete(channel.client);
+        channel.destroy();
+      });
     });
     this.protocol = protocol;
     this.host = host;
@@ -111,14 +115,12 @@ class Server {
 
   closeChannels() {
     for (const [client, channel] of channels.entries()) {
-      channels.delete(client);
       if (channel.connection) {
         channel.connection.terminate();
       } else {
         channel.error(503);
         channel.req.connection.destroy();
       }
-      channel.destroy();
     }
   }
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
