### PR TITLE
Add Client event: 'close' for http and websockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update metautil to 3.5.0, change `await timeout` to `await delay`
 - Remove channel from collection on connections close
+- Add Client event: 'close' for http and websockets
 
 ## [1.5.1][] - 2021-02-19
 

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -56,7 +56,13 @@ const channels = new Map();
 
 class Client {
   constructor() {
+    this.events = { close: [] };
     this.callId = 0;
+  }
+
+  on(name, callback) {
+    if (name !== 'close') return;
+    this.events.close.push(callback);
   }
 
   emit(name, data) {
@@ -260,6 +266,7 @@ class Channel {
   }
 
   destroy() {
+    for (const callback of this.client.events.close) callback();
     if (!this.session) return;
     const token = this.session.token;
     sessions.delete(token);


### PR DESCRIPTION
Closes: https://github.com/metarhia/metacom/issues/137

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
