### PR TITLE
Delegate socket on 'error' handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update metautil to 3.5.0, change `await timeout` to `await delay`
 - Remove channel from collection on connections close
 - Add Client event: 'close' for http and websockets
+- Delegate server socket on 'error' handler
 
 ## [1.5.1][] - 2021-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Update metautil to 3.5.0, change `await timeout` to `await delay`
 - Remove channel from collection on connections close
 - Add Client event: 'close' for http and websockets
-- Delegate server socket on 'error' handler
+- Delegate server and browser socket on 'error' handler
 
 ## [1.5.1][] - 2021-02-19
 

--- a/dist/metacom.js
+++ b/dist/metacom.js
@@ -149,7 +149,8 @@ class WebsocketTransport extends Metacom {
       }, this.reconnectTimeout);
     });
 
-    socket.addEventListener('error', () => {
+    socket.addEventListener('error', (err) => {
+      this.emit('error', err);
       socket.close();
     });
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -2,6 +2,7 @@
 
 const http = require('http');
 const https = require('https');
+const { EventEmitter } = require('events');
 const transport = { http, https };
 const WebSocket = require('ws');
 
@@ -29,8 +30,9 @@ const fetch = (url, options) => {
   });
 };
 
-class Metacom {
+class Metacom extends EventEmitter {
   constructor(url) {
+    super();
     this.url = url;
     this.socket = new WebSocket(url);
     this.api = {};
@@ -52,6 +54,9 @@ class Metacom {
       } catch (err) {
         console.error(err);
       }
+    });
+    this.socket.addEventListener('error', (err) => {
+      this.emit('error', err);
     });
   }
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
