### PR TITLE
Marshal timeout error to the client side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Marshal timeout error to the client side
+
 ## [1.5.2][] - 2021-02-23
 
 - Update metautil to 3.5.0, change `await timeout` to `await delay`

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -213,7 +213,8 @@ class Channel {
     try {
       result = await proc.invoke(context, args);
     } catch (err) {
-      this.error(500, err, callId);
+      const code = err.message === 'Timeout reached' ? 408 : 500;
+      this.error(code, err, callId);
     } finally {
       proc.leave();
     }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
