### PR TITLE
Port re-bind

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -27,13 +27,22 @@ class Server {
     this.config = config;
     this.application = application;
     const { host, balancer, protocol, ports, queue } = config;
-    const { nagle = true } = config;
     const concurrency = queue.concurrency || config.concurrency;
     this.semaphore = new Semaphore(concurrency, queue.size, queue.timeout);
     const { threadId } = worker;
     this.balancer = balancer && threadId === 1;
     const skipBalancer = balancer ? 1 : 0;
     this.port = this.balancer ? balancer : ports[threadId - skipBalancer - 1];
+    this.server = null;
+    this.ws = null;
+    this.protocol = protocol;
+    this.host = host;
+    this.bind();
+  }
+
+  bind() {
+    const { config, application, port, host } = this;
+    const { protocol, nagle = true } = config;
     const transport = protocol === 'http' || this.balancer ? http : https;
     const listener = this.listener.bind(this);
     this.server = transport.createServer({ ...application.cert }, listener);
@@ -53,9 +62,7 @@ class Server {
         channel.destroy();
       });
     });
-    this.protocol = protocol;
-    this.host = host;
-    this.server.listen(this.port, host);
+    this.server.listen(port, host);
   }
 
   async listener(req, res) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,7 +2,7 @@
 
 const http = require('http');
 const https = require('https');
-const worker = require('worker_threads');
+const { threadId } = require('worker_threads');
 
 const metautil = require('metautil');
 const { Semaphore } = metautil;
@@ -29,7 +29,6 @@ class Server {
     const { host, balancer, protocol, ports, queue } = config;
     const concurrency = queue.concurrency || config.concurrency;
     this.semaphore = new Semaphore(concurrency, queue.size, queue.timeout);
-    const { threadId } = worker;
     this.balancer = balancer && threadId === 1;
     const skipBalancer = balancer ? 1 : 0;
     this.port = this.balancer ? balancer : ports[threadId - skipBalancer - 1];
@@ -42,7 +41,7 @@ class Server {
 
   bind() {
     const { config, application, port, host } = this;
-    const { protocol, nagle = true } = config;
+    const { protocol, timeouts, nagle = true } = config;
     const transport = protocol === 'http' || this.balancer ? http : https;
     const listener = this.listener.bind(this);
     this.server = transport.createServer({ ...application.cert }, listener);
@@ -51,6 +50,9 @@ class Server {
         socket.setNoDelay(true);
       });
     }
+    this.server.on('listening', () => {
+      application.console.info(`Listen port ${port} in worker ${threadId}`);
+    });
     this.ws = new ws.Server({ server: this.server });
     this.ws.on('connection', async (connection, req) => {
       const channel = await new Channel(req, null, connection, application);
@@ -61,6 +63,13 @@ class Server {
         channels.delete(channel.client);
         channel.destroy();
       });
+    });
+    this.ws.on('error', (err) => {
+      if (err.code !== 'EADDRINUSE') return;
+      application.console.warn(`Address in use: ${host}:${port}, retry...`);
+      setTimeout(() => {
+        this.bind();
+      }, timeouts.bind);
     });
     this.server.listen(port, host);
   }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
