### PR TITLE
Read timeouts from config

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -10,9 +10,7 @@ const ws = require('ws');
 
 const { Channel, channels } = require('./channel.js');
 
-const SHUTDOWN_TIMEOUT = 5000;
 const SHORT_TIMEOUT = 500;
-const LONG_RESPONSE = 30000;
 
 const receiveBody = async (req) => {
   const buffers = [];
@@ -86,7 +84,7 @@ class Server {
       channels.delete(client);
       channel.error(504);
       channel.destroy();
-    }, LONG_RESPONSE);
+    }, this.config.timeouts.request);
 
     res.on('close', () => {
       if (finished) return;
@@ -155,7 +153,7 @@ class Server {
       await metautil.delay(SHORT_TIMEOUT);
       return;
     }
-    await metautil.delay(SHUTDOWN_TIMEOUT);
+    await metautil.delay(this.config.timeouts.stop);
     this.closeChannels();
   }
 }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
