### PR TITLE
Update Metacom exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Update Metacom exports
+
 ## [1.7.3][] - 2021-06-08
 
 - Fix passing validation error to the client

--- a/metacom.js
+++ b/metacom.js
@@ -4,6 +4,6 @@ const { Metacom } = require('./lib/client.js');
 const { Server } = require('./lib/server.js');
 const { Channel } = require('./lib/channel.js');
 
-module.exports = Metacom;
+module.exports.Metacom = Metacom;
 module.exports.Server = Server;
 module.exports.Channel = Channel;


### PR DESCRIPTION
- [x] description of changes is added in CHANGELOG.md

Update `Metacom` export to match other exports, examples, and typings.

E.g. a line from `README.md`
```
// Load at backend
const { Metacom } = require('metacom');
```

Alternatively, we can\should update `README.md` and typings.