### PR TITLE
Throw errors on wrong configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Throw errors on wrong configs
+
 ## [1.7.3][] - 2021-06-08
 
 - Fix passing validation error to the client

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,6 +22,7 @@ const receiveBody = async (req) => {
 
 class Server {
   constructor(config, application) {
+    if (threadId === 0) throw new Error(`Thread 0 is intended for system use`);
     this.config = config;
     this.application = application;
     const { host, balancer, protocol, ports, queue } = config;
@@ -29,7 +30,9 @@ class Server {
     this.semaphore = new Semaphore(concurrency, queue.size, queue.timeout);
     this.balancer = balancer && threadId === 1;
     const skipBalancer = balancer ? 1 : 0;
-    this.port = this.balancer ? balancer : ports[threadId - skipBalancer - 1];
+    const port = this.balancer ? balancer : ports[threadId - skipBalancer - 1];
+    if (!port) throw new Error(`No port configured thread ${threadId}`);
+    this.port = port;
     this.server = null;
     this.ws = null;
     this.protocol = protocol;


### PR DESCRIPTION
Refs: #200 
- [ ] tests and linter show no problems (`npm t`)
- [ ] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
