### PR TITLE
Add support of returning index.html not only from the root folder, an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+- Add support of returning index.html as default not only from the root folder
+- Add custom 404-page support
+
 ## [2.0.3][] - 2021-09-23
 
 - Remove `toString` in `receiveBody` to be compatible with ws

--- a/lib/server.js
+++ b/lib/server.js
@@ -71,15 +71,15 @@ class Server {
   listener(req, res) {
     const { url } = req;
     const channel = transport.http.createChannel(this.application, req, res);
+    const { protocol } = this.config;
     if (this.balancer) {
       const host = metautil.parseHost(req.headers.host);
       const port = metautil.sample(this.config.ports);
-      const { protocol } = this.config;
       channel.redirect(`${protocol}://${host}:${port}/`);
       return;
     }
     if (url.startsWith('/api')) this.request(channel);
-    else serveStatic(channel);
+    else serveStatic(channel, protocol);
   }
 
   request(channel) {

--- a/lib/static.js
+++ b/lib/static.js
@@ -2,15 +2,27 @@
 
 const path = require('path');
 
-const serveStatic = (channel) => {
+const serveStatic = (channel, protocol) => {
   const { req, res, application } = channel;
+  const {
+    headers: { host },
+  } = req;
+  const redirect = `${protocol}://${host}`;
   if (res.writableEnded) return;
   const { url } = req;
-  const filePath = url === '/' ? '/index.html' : url;
+  const filePath = url.endsWith('/') ? url + 'index.html' : url;
   const fileExt = path.extname(filePath).substring(1);
   const data = application.getStaticFile(filePath);
-  if (data) channel.write(data, 200, fileExt);
-  else channel.error(404);
+  if (data) {
+    channel.write(data, 200, fileExt);
+  } else {
+    if (fileExt === '') {
+      channel.redirect(`${redirect}${filePath}/`);
+      return;
+    }
+    const handle404 = application.getStaticFile('/404/index.html');
+    handle404 ? channel.redirect(`${redirect}/404/`) : channel.error(404);
+  }
 };
 
 module.exports = { serveStatic };


### PR DESCRIPTION
Add support of returning index.html not only from the root folder, and custom 404-page

- [ x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [ x] code is properly formatted (`npm run fmt`)
- [ x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
