### PR TITLE
Fix http error code passing without explicit httpCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Fix missing channel handling in Client
+- Fix default `httpCode` in `Channel#error()` calls
 
 ## [2.0.5][] - 2022-03-18
 

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -143,8 +143,7 @@ class Channel {
       if (error.message === 'Timeout reached') {
         error.code = error.httpCode = 408;
       }
-      const httpCode = error.httpCode || error.code;
-      this.error(error.code, { callId, error, httpCode });
+      this.error(error.code, { callId, error });
       return;
     } finally {
       proc.leave();
@@ -159,9 +158,10 @@ class Channel {
     application.console.log(record);
   }
 
-  error(code = 500, { callId, error = null, httpCode = 500 } = {}) {
+  error(code = 500, { callId, error = null, httpCode = null } = {}) {
     const { req, ip, application } = this;
     const { url, method } = req;
+    if (!httpCode) httpCode = (error && error.httpCode) || code;
     const status = http.STATUS_CODES[httpCode];
     const pass = httpCode < 500 || httpCode > 599;
     const message = pass && error ? error.message : status || 'Unknown error';


### PR DESCRIPTION
Otherwise, all entries like this.error(403, { callId }) would be
reported as 500 without proper error message.

<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
