### PR TITLE
Prevent return after semaphore enter

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -125,15 +125,15 @@ class Channel {
       this.error(404, { callId });
       return;
     }
+    const context = session ? session.context : { client };
+    if (!this.session && proc.access !== 'public') {
+      this.error(403, { callId });
+      return;
+    }
     try {
       await proc.enter();
     } catch {
       this.error(503, { callId });
-      return;
-    }
-    const context = session ? session.context : { client };
-    if (!this.session && proc.access !== 'public') {
-      this.error(403, { callId });
       return;
     }
     let result = null;


### PR DESCRIPTION
This is hot fix and needs to be landed ASAP.
Before: check access and return after entering Semaphore without live.
Bug: Semaphore only enters
Fix: check access before entering semaphore removes this issue.
Was discovered with this issue: https://github.com/metarhia/metautil/pull/100

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)

@tshemsedinov please land
