### PR TITLE
Pass certain port for `Server` in `options`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased][unreleased]
 
-- Pass certain port for `Server` in `options`
+- Pass certain port for `Server` in `options`, do not pass `threadId`
 
 ## [2.0.7][] - 2022-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Pass certain port for `Server` in `options`
+
 ## [2.0.7][] - 2022-05-09
 
 - Fix client to support falsy results parsing

--- a/lib/server.js
+++ b/lib/server.js
@@ -55,7 +55,7 @@ class Server {
   listener(req, res) {
     const { url } = req;
     const channel = transport.http.createChannel(this.application, req, res);
-    if (this.kind === 'balancer') {
+    if (this.options.kind === 'balancer') {
       const host = metautil.parseHost(req.headers.host);
       const port = metautil.sample(this.options.ports);
       const { protocol } = this.options;

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,7 +2,6 @@
 
 const http = require('http');
 const https = require('https');
-const { threadId } = require('worker_threads');
 const metautil = require('metautil');
 const { Semaphore } = metautil;
 const ws = require('ws');
@@ -13,30 +12,22 @@ const transport = require('./transport.js');
 const SHORT_TIMEOUT = 500;
 
 class Server {
-  constructor(config, application) {
-    if (threadId === 0) throw new Error(`Thread 0 is intended for system use`);
-    this.config = config;
+  constructor(options, application) {
+    const { cors, queue } = options;
+    this.options = options;
     this.application = application;
-    const { host, balancer, protocol, ports, queue, cors } = config;
     if (cors) transport.http.addHeaders(cors);
-    const concurrency = queue.concurrency || config.concurrency;
+    const concurrency = queue.concurrency || options.concurrency;
     this.semaphore = new Semaphore(concurrency, queue.size, queue.timeout);
-    this.balancer = balancer && threadId === 1;
-    const skipBalancer = balancer ? 1 : 0;
-    const port = this.balancer ? balancer : ports[threadId - skipBalancer - 1];
-    if (!port) throw new Error(`No port configured thread ${threadId}`);
-    this.port = port;
     this.server = null;
     this.ws = null;
-    this.protocol = protocol;
-    this.host = host;
     this.bind();
   }
 
   bind() {
-    const { config, application, port, host } = this;
-    const { protocol, timeouts, nagle = true } = config;
-    const proto = protocol === 'http' || this.balancer ? http : https;
+    const { options, application } = this;
+    const { host, port, kind, protocol, timeouts, nagle = true } = options;
+    const proto = protocol === 'http' || kind === 'balancer' ? http : https;
     const listener = this.listener.bind(this);
     this.server = proto.createServer({ ...application.cert }, listener);
     if (!nagle) {
@@ -45,7 +36,7 @@ class Server {
       });
     }
     this.server.on('listening', () => {
-      application.console.info(`Listen port ${port} in worker ${threadId}`);
+      application.console.info(`Listen port ${port}`);
     });
     this.ws = new ws.Server({ server: this.server });
     this.ws.on('connection', (connection, req) => {
@@ -64,10 +55,10 @@ class Server {
   listener(req, res) {
     const { url } = req;
     const channel = transport.http.createChannel(this.application, req, res);
-    if (this.balancer) {
+    if (this.kind === 'balancer') {
       const host = metautil.parseHost(req.headers.host);
-      const port = metautil.sample(this.config.ports);
-      const { protocol } = this.config;
+      const port = metautil.sample(this.options.ports);
+      const { protocol } = this.options;
       channel.redirect(`${protocol}://${host}:${port}/`);
       return;
     }
@@ -135,7 +126,7 @@ class Server {
       await metautil.delay(SHORT_TIMEOUT);
       return;
     }
-    await metautil.delay(this.config.timeouts.stop);
+    await metautil.delay(this.options.timeouts.stop);
     this.closeChannels();
   }
 }

--- a/metacom.d.ts
+++ b/metacom.d.ts
@@ -27,10 +27,11 @@ export class Metacom extends EventEmitter {
   ): (methodName: string) => (args: object) => Promise<void>;
 }
 
-export interface ServerConfig {
+export interface Options {
   concurrency: number;
   host: string;
-  balancer: boolean;
+  port: number;
+  kind: 'server' | 'balancer';
   protocol: string;
   ports: Array<number>;
   queue: object;
@@ -108,16 +109,12 @@ export class WsChannel extends Channel {
 }
 
 export class Server {
-  config: ServerConfig;
+  options: Options;
   application: object;
   semaphore: Semaphore;
-  balancer: boolean;
-  port: number;
   server?: any;
   ws?: any;
-  protocol: string;
-  host: string;
-  constructor(config: ServerConfig, application: object);
+  constructor(options: Options, application: object);
   bind(): void;
   listener(req: ClientRequest, res: ServerResponse): void;
   request(channel: Channel): void;


### PR DESCRIPTION
- Don't use threadId in Server class
- We need it to start server in any thread
- Also we need it for multitenancy

Closes: https://github.com/metarhia/metacom/issues/302
Refs: https://github.com/metarhia/impress/pull/1739

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
