### PR TITLE
Pass http verb to the hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Pass http verb to the hook
+
 ## [2.0.7][] - 2022-05-09
 
 - Fix client to support falsy results parsing

--- a/lib/http.js
+++ b/lib/http.js
@@ -119,7 +119,8 @@ class HttpChannel extends Channel {
   }
 
   async hook(proc, interfaceName, methodName, args, headers) {
-    const { application, client, req: { method: verb } } = this;
+    const { application, client, req } = this;
+    const verb = req.method;
     const callId = -1;
     if (!proc) {
       this.error(404, { callId });
@@ -128,7 +129,8 @@ class HttpChannel extends Channel {
     const context = { client };
     let result = null;
     try {
-      result = await proc.invoke(context, { verb, method: methodName, args });
+      const par = { verb, method: methodName, args, headers };
+      result = await proc.invoke(context, par);
     } catch (error) {
       this.error(500, { callId, error });
       return;

--- a/lib/http.js
+++ b/lib/http.js
@@ -118,8 +118,8 @@ class HttpChannel extends Channel {
     res.end();
   }
 
-  async hook(proc, interfaceName, methodName, args) {
-    const { application, client } = this;
+  async hook(proc, interfaceName, methodName, args, headers) {
+    const { application, client, req: { method: verb } } = this;
     const callId = -1;
     if (!proc) {
       this.error(404, { callId });
@@ -128,7 +128,7 @@ class HttpChannel extends Channel {
     const context = { client };
     let result = null;
     try {
-      result = await proc.invoke(context, { method: methodName, args });
+      result = await proc.invoke(context, { verb, method: methodName, args });
     } catch (error) {
       this.error(500, { callId, error });
       return;


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
