### PR TITLE
Fix serve static files with query in URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add stream types
 - Fix browser client WebsocketTransport open
 - Add method for a possibility to delete session token from the application routes
+- Fix serve static files with query in URL
 
 ## [3.0.0-alpha.2][] - 2022-07-07
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const metautil = require('metautil');
 
 const index = (url) => path.join(url, 'index.html');
 
@@ -8,7 +9,8 @@ const serveStatic = (channel) => {
   const { req, res, application } = channel;
   if (res.writableEnded) return;
   const { url } = req;
-  const filePath = url.endsWith('/') ? index(url) : url;
+  const [urlPath, params] = metautil.split(url, '?');
+  const filePath = urlPath.endsWith('/') ? index(urlPath) : urlPath;
   const fileExt = path.extname(filePath).substring(1);
   const data = application.getStaticFile(filePath);
   if (data) {
@@ -17,7 +19,7 @@ const serveStatic = (channel) => {
   }
   if (fileExt !== 'html') {
     if (application.getStaticFile(index(filePath))) {
-      channel.redirect(filePath + '/');
+      channel.redirect(filePath + '/' + params);
       return;
     }
   }

--- a/lib/static.js
+++ b/lib/static.js
@@ -12,6 +12,7 @@ const serveStatic = (channel) => {
   const [urlPath, params] = metautil.split(url, '?');
   const filePath = urlPath.endsWith('/') ? index(urlPath) : urlPath;
   const fileExt = path.extname(filePath).substring(1);
+  console.log({ url, urlPath, params, filePath, fileExt });
   const data = application.getStaticFile(filePath);
   if (data) {
     channel.write(data, 200, fileExt);
@@ -19,7 +20,8 @@ const serveStatic = (channel) => {
   }
   if (fileExt !== 'html') {
     if (application.getStaticFile(index(filePath))) {
-      channel.redirect(filePath + '/' + params);
+      const query = params ? '?' + params : '';
+      channel.redirect(filePath + '/' + query);
       return;
     }
   }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
