### PR TITLE
Remove debug output

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -12,7 +12,6 @@ const serveStatic = (channel) => {
   const [urlPath, params] = metautil.split(url, '?');
   const filePath = urlPath.endsWith('/') ? index(urlPath) : urlPath;
   const fileExt = path.extname(filePath).substring(1);
-  console.log({ url, urlPath, params, filePath, fileExt });
   const data = application.getStaticFile(filePath);
   if (data) {
     channel.write(data, 200, fileExt);


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
