### PR TITLE
Server-side stream writing better abstraction

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -84,8 +84,7 @@ class Client {
     if (!size) throw new Error('Stream size is not provided');
     const streamId = --this.streamId;
     const initData = { streamId, name, size };
-    const transport = channel.connection;
-    return new MetacomWritable(transport, initData);
+    return new MetacomWritable(channel, initData);
   }
 
   startSession(token, data = {}) {

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -164,25 +164,25 @@ class MetacomWritable extends EventEmitter {
       name: this.name,
       size: this.size,
     };
-    this.transport.send(JSON.stringify(packet));
+    this.transport.write(JSON.stringify(packet));
   }
 
   // implements nodejs writable write method
   write(data) {
     const chunk = MetacomChunk.encode(this.streamId, data);
-    this.transport.send(chunk);
+    this.transport.write(chunk);
     return true;
   }
 
   // implements nodejs writable end method
   end() {
     const packet = { stream: this.streamId, status: 'end' };
-    this.transport.send(JSON.stringify(packet));
+    this.transport.write(JSON.stringify(packet));
   }
 
   terminate() {
     const packet = { stream: this.streamId, status: 'terminate' };
-    this.transport.send(JSON.stringify(packet));
+    this.transport.write(JSON.stringify(packet));
   }
 }
 

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -149,9 +149,9 @@ class MetacomReadable extends EventEmitter {
 }
 
 class MetacomWritable extends EventEmitter {
-  constructor(transport, initData) {
+  constructor(channel, initData) {
     super();
-    this.transport = transport;
+    this.channel = channel;
     this.streamId = initData.streamId;
     this.name = initData.name;
     this.size = initData.size;
@@ -164,25 +164,25 @@ class MetacomWritable extends EventEmitter {
       name: this.name,
       size: this.size,
     };
-    this.transport.write(JSON.stringify(packet));
+    this.channel.write(JSON.stringify(packet));
   }
 
   // implements nodejs writable write method
   write(data) {
     const chunk = MetacomChunk.encode(this.streamId, data);
-    this.transport.write(chunk);
+    this.channel.write(chunk);
     return true;
   }
 
   // implements nodejs writable end method
   end() {
     const packet = { stream: this.streamId, status: 'end' };
-    this.transport.write(JSON.stringify(packet));
+    this.channel.write(JSON.stringify(packet));
   }
 
   terminate() {
     const packet = { stream: this.streamId, status: 'terminate' };
-    this.transport.write(JSON.stringify(packet));
+    this.channel.write(JSON.stringify(packet));
   }
 }
 

--- a/test/streams.js
+++ b/test/streams.js
@@ -28,8 +28,8 @@ const generateDataView = () => {
 
 const createWritable = (initData) => {
   const writeBuffer = [];
-  const transport = { send: (packet) => writeBuffer.push(packet) };
-  const stream = new MetacomWritable(transport, initData);
+  const channel = { write: (packet) => writeBuffer.push(packet) };
+  const stream = new MetacomWritable(channel, initData);
   return [stream, writeBuffer];
 };
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [ ] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [ ] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

Here we pass `channel.connection` (where `WebSocket` implementation from `ws` library is) to `MetacomWritable`:

https://github.com/metarhia/metacom/blob/be5faa03e7d12460f3360038d89cc1571cf53a49/lib/channel.js#L78-L89

Later `MetacomWritable` is writing directly to websockets using the `WebSocket.send()` method.

https://github.com/metarhia/metacom/blob/be5faa03e7d12460f3360038d89cc1571cf53a49/lib/streams.js#L151-L187

Is it how it's supposed to be?
I feel like it should rather depend on `WsChannel` class contracts, calling its methods instead.
I suggest we use `WsChannel.write()` to send both binary and objects packages (or we could use `WsChannel.write()` for binary and `WsChannel.send()` for objects as it stringifies them inside).