### PR TITLE
Fix httpCall for Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased][unreleased]
 
+- Fix `httpCall` for `Client`
 - Fix `close` event call for `Client` instance on `Channel` destroy
 
 ## [3.0.0-alpha.5][] - 2022-12-23

--- a/lib/client.js
+++ b/lib/client.js
@@ -177,7 +177,7 @@ class Metacom extends EventEmitter {
         const res = await metautil.fetch(url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: packet,
+          body: JSON.stringify(packet),
         });
         const data = await res.json();
         if (data.error) throw new MetacomError(data.error);

--- a/lib/client.js
+++ b/lib/client.js
@@ -174,10 +174,10 @@ class Metacom extends EventEmitter {
         const dest = new URL(this.url);
         const protocol = dest.protocol === 'ws:' ? 'http' : 'https';
         const url = `${protocol}://${dest.host}/api`;
-        const res = metautil.fetch(url, {
+        const res = await metautil.fetch(url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(packet),
+          body: packet,
         });
         const data = await res.json();
         if (data.error) throw new MetacomError(data.error);


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

Fix unnecessary `JSON.stringify` calling when global fetch is used.
Add awating to `metautil.fetch` because of it returns Promise and calling of await `res.json` further throws an error:
`json() is not a function`