### PR TITLE
Generate UUID for RPC calls with `Context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased][unreleased]
 
 - Add `node:` prefix for all internal modules
+- Generate UUID for each RPC call to track logic
+- Add `Context` and `State` classes
+- Fix typings: remove internal module classes, add some exported
 
 ## [3.0.0-alpha.6][] - 2023-02-13
 

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -7,27 +7,40 @@ const { MetaReadable, MetaWritable, Chunk } = require('./streams.js');
 
 const EMPTY_PACKET = Buffer.from('{}');
 
+const createProxy = (data, save) =>
+  new Proxy(data, {
+    get: (data, key) => {
+      return Reflect.get(data, key);
+    },
+    set: (data, key, value) => {
+      const res = Reflect.set(data, key, value);
+      if (save) save(data);
+      return res;
+    },
+  });
+
 class Session {
   constructor(token, channel, data) {
     this.token = token;
     this.channels = new Set([channel]);
     this.data = data;
-    this.context = new Proxy(data, {
-      get: (data, key) => {
-        if (key === 'token') return token;
-        if (key === 'client') return channel.client;
-        return Reflect.get(data, key);
-      },
-      set: (data, key, value) => {
-        const res = Reflect.set(data, key, value);
-        channel.auth.saveSession(token, data);
-        return res;
-      },
+    const state = createProxy(data, (data) => {
+      channel.auth.saveSession(token, data);
     });
+    this.instance = { token, state };
   }
 }
 
 const sessions = new Map(); // token: Session
+
+class Context {
+  constructor(channel) {
+    this.client = channel.client;
+    this.uuid = metautil.generateUUID();
+    this.state = {};
+    this.session = channel.session.instance;
+  }
+}
 
 class Client extends EventEmitter {
   #channel;
@@ -38,6 +51,7 @@ class Client extends EventEmitter {
     this.eventId = 0;
     this.streams = new Map();
     this.streamId = 0;
+    this.auth = channel.auth;
   }
 
   redirect(location) {
@@ -204,15 +218,19 @@ class Channel {
     }
   }
 
+  createContext() {
+    return new Context(this);
+  }
+
   async rpc(callId, interfaceName, methodName, args) {
-    const { server, console, session, client } = this;
+    const { server, console } = this;
     const [iname, ver = '*'] = interfaceName.split('.');
     const proc = server.application.getMethod(iname, ver, methodName);
     if (!proc) {
       this.error(404, { callId });
       return;
     }
-    const context = session ? session.context : { client };
+    const context = this.createContext();
     if (!this.session && proc.access !== 'public') {
       this.error(403, { callId });
       return;

--- a/lib/http.js
+++ b/lib/http.js
@@ -119,14 +119,14 @@ class HttpChannel extends Channel {
   }
 
   async hook(proc, interfaceName, methodName, args, headers) {
-    const { console, client, req } = this;
+    const { console, req } = this;
     const verb = req.method;
     const callId = -1;
     if (!proc) {
       this.error(404, { callId });
       return;
     }
-    const context = { client };
+    const context = this.createContext(this);
     let result = null;
     try {
       const par = { verb, method: methodName, args, headers };

--- a/metacom.d.ts
+++ b/metacom.d.ts
@@ -65,10 +65,6 @@ export interface Options {
   queue: object;
 }
 
-export class Session {
-  constructor(token: string, channel: Channel, data: any);
-}
-
 export interface ErrorOptions {
   callId?: number;
   error?: Error;
@@ -87,8 +83,10 @@ export interface Auth {
 
 export class Client extends EventEmitter {
   ip: string | undefined;
+  callId: number;
   eventId: number;
   streamId: number;
+  auth: Auth;
   events: { close: Array<Function> };
   streams: Map<number, MetaReadable>;
   redirect(location: string): void;
@@ -166,4 +164,20 @@ export class Server {
   request(channel: Channel): void;
   closeChannels(): void;
   close(): Promise<void>;
+}
+
+export interface State {
+  [key: string]: any;
+}
+
+export interface Session {
+  token: string;
+  state: State;
+}
+
+export interface Context {
+  client: Client;
+  uuid: string;
+  state: State;
+  session: Session;
 }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
