### PR TITLE
Optimize server-side classes

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -45,9 +45,6 @@ class Client extends EventEmitter {
   constructor(channel) {
     super();
     this.#channel = channel;
-    this.eventId = 0;
-    this.streams = new Map();
-    this.streamId = 0;
     this.auth = channel.auth;
   }
 
@@ -64,32 +61,15 @@ class Client extends EventEmitter {
       super.emit(name, data);
       return;
     }
-    const packet = { event: --this.eventId, [name]: data };
-    if (!this.#channel || !this.#channel.connection) {
-      throw new Error(`Can't send metacom events to http transport`);
-    }
-    this.#channel.send(packet);
+    this.#channel.sendEvent(name, data);
   }
 
   getStream(streamId) {
-    if (!this.#channel.connection) {
-      throw new Error(`Can't receive stream from http transport`);
-    }
-    const stream = this.streams.get(streamId);
-    if (stream) return stream;
-    throw new Error(`Stream ${streamId} is not initialized`);
+    return this.#channel.getStream(streamId);
   }
 
   createStream(name, size) {
-    if (!this.#channel.connection) {
-      throw new Error(`Can't send metacom streams to http transport`);
-    }
-    if (!name) throw new Error('Stream name is not provided');
-    if (!size) throw new Error('Stream size is not provided');
-    const streamId = --this.streamId;
-    const initData = { streamId, name, size };
-    const transport = this.#channel.connection;
-    return new MetaWritable(transport, initData);
+    return this.#channel.createStream(name, size);
   }
 
   initializeSession(token, data = {}) {
@@ -134,6 +114,9 @@ class Channel {
     this.ip = req.socket.remoteAddress;
     this.client = new Client(this);
     this.session = null;
+    this.eventId = 0;
+    this.streamId = 0;
+    this.streams = new Map();
   }
 
   get token() {
@@ -167,7 +150,7 @@ class Channel {
   binary(data) {
     try {
       const { streamId, payload } = Chunk.decode(data);
-      const upstream = this.client.streams.get(streamId);
+      const upstream = this.streams.get(streamId);
       if (upstream) {
         upstream.push(payload);
       } else {
@@ -195,7 +178,7 @@ class Channel {
 
   async handleStreamPacket(packet) {
     const { stream: streamId, name, size, status } = packet;
-    const stream = this.client.streams.get(streamId);
+    const stream = this.streams.get(streamId);
     if (name && typeof name === 'string' && Number.isSafeInteger(size)) {
       if (stream) {
         const error = new Error(`Stream ${name} is already initialized`);
@@ -203,17 +186,17 @@ class Channel {
       } else {
         const streamData = { streamId, name, size };
         const stream = new MetaReadable(streamData);
-        this.client.streams.set(streamId, stream);
+        this.streams.set(streamId, stream);
       }
     } else if (!stream) {
       const error = new Error(`Stream ${streamId} is not initialized`);
       this.error(400, { callId: streamId, error, pass: true });
     } else if (status === 'end') {
       await stream.close();
-      this.client.streams.delete(streamId);
+      this.streams.delete(streamId);
     } else if (status === 'terminate') {
       await stream.terminate();
-      this.client.streams.delete(streamId);
+      this.streams.delete(streamId);
     } else {
       const error = new Error('Stream packet structure error');
       this.error(400, { callId: streamId, error, pass: true });
@@ -275,6 +258,35 @@ class Channel {
     console.error(`${ip}\t${method}\t${url}\t${reason}`);
     const packet = { callback: callId, error: { message, code } };
     this.send(packet, httpCode);
+  }
+
+  sendEvent(name, data) {
+    const packet = { event: --this.eventId, [name]: data };
+    if (!this.connection) {
+      throw new Error(`Can't send metacom events to http transport`);
+    }
+    this.send(packet);
+  }
+
+  getStream(streamId) {
+    if (!this.connection) {
+      throw new Error(`Can't receive stream from http transport`);
+    }
+    const stream = this.streams.get(streamId);
+    if (stream) return stream;
+    throw new Error(`Stream ${streamId} is not initialized`);
+  }
+
+  createStream(name, size) {
+    if (!this.connection) {
+      throw new Error(`Can't send metacom streams to http transport`);
+    }
+    if (!name) throw new Error('Stream name is not provided');
+    if (!size) throw new Error('Stream size is not provided');
+    const streamId = --this.streamId;
+    const initData = { streamId, name, size };
+    const transport = this.connection;
+    return new MetaWritable(transport, initData);
   }
 
   async resumeCookieSession() {

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -22,12 +22,9 @@ const createProxy = (data, save) =>
 class Session {
   constructor(token, channel, data) {
     this.token = token;
-    this.channels = new Set([channel]);
-    this.data = data;
-    const state = createProxy(data, (data) => {
+    this.state = createProxy(data, (data) => {
       channel.auth.saveSession(token, data).catch(channel.console.error);
     });
-    this.instance = { token, state };
   }
 }
 
@@ -38,7 +35,7 @@ class Context {
     this.client = channel.client;
     this.uuid = metautil.generateUUID();
     this.state = {};
-    this.session = channel?.session?.instance || null;
+    this.session = channel?.session || null;
   }
 }
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
