### PR TITLE
Unify server-side and browser `streams` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Fix server-side client
-- Sync browser and server-side clients codebase
+- Unify server-side and browser `streams` implementation
 - Update metautil to 3.7.1 for fixed `fetch`
 
 ## [3.0.0-alpha.7][] - 2023-02-09

--- a/dist/metacom.js
+++ b/dist/metacom.js
@@ -22,7 +22,7 @@ class MetacomError extends Error {
 
 class MetacomInterface extends EventEmitter {}
 
-export class Metacom extends EventEmitter {
+class Metacom extends EventEmitter {
   constructor(url, options = {}) {
     super();
     this.url = url;
@@ -277,3 +277,5 @@ Metacom.transport = {
   ws: WebsocketTransport,
   http: HttpTransport,
 };
+
+export { Metacom };

--- a/dist/streams.js
+++ b/dist/streams.js
@@ -97,13 +97,11 @@ class MetaReadable extends EventEmitter {
   }
 
   async stop() {
-    if (this.bytesRead === this.size) {
-      this.streaming = false;
-      this.emit(PUSH_EVENT, null);
-    } else {
+    while (this.bytesRead !== this.size) {
       await this.waitEvent(PULL_EVENT);
-      await this.stop();
     }
+    this.streaming = false;
+    this.emit(PUSH_EVENT, null);
   }
 
   async read() {
@@ -166,6 +164,7 @@ class MetaWritable extends EventEmitter {
   write(data) {
     const chunk = Chunk.encode(this.streamId, data);
     this.transport.send(chunk);
+    return true;
   }
 
   end() {

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -76,7 +76,6 @@ class MetaReadable extends EventEmitter {
     await this.close();
   }
 
-  // implements nodejs readable pipe method
   pipe(writable) {
     void this.finalize(writable);
     return writable;
@@ -165,14 +164,12 @@ class MetaWritable extends EventEmitter {
     this.transport.send(JSON.stringify(packet));
   }
 
-  // implements nodejs writable write method
   write(data) {
     const chunk = Chunk.encode(this.streamId, data);
     this.transport.send(chunk);
     return true;
   }
 
-  // implements nodejs writable end method
   end() {
     const packet = { stream: this.streamId, status: 'end' };
     this.transport.send(JSON.stringify(packet));


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
