### PR TITLE
Pass `null` to `res` instead of `undefined`

### DIFF
--- a/lib/ws.js
+++ b/lib/ws.js
@@ -4,7 +4,7 @@ const { Channel } = require('./channel.js');
 
 class WsChannel extends Channel {
   constructor(server, req, connection) {
-    super(server, req);
+    super(server, req, null);
     this.connection = connection;
     connection.on('message', (data, isBinary) => {
       if (isBinary) this.binary(data);


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
