### PR TITLE
Clear client intervals and timeouts after call `close`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Fix `close` method of `Client` to properly clear all timeouts and intervals
+
 ## [3.0.0-alpha.8][] - 2023-02-13
 
 - Fix server-side client

--- a/lib/client.js
+++ b/lib/client.js
@@ -40,9 +40,12 @@ class Metacom extends EventEmitter {
     this.connected = false;
     this.opening = null;
     this.lastActivity = new Date().getTime();
-    this.callTimeout = options.callTimeout || CALL_TIMEOUT;
-    this.pingInterval = options.pingInterval || PING_INTERVAL;
-    this.reconnectTimeout = options.reconnectTimeout || RECONNECT_TIMEOUT;
+    this.callTimeouts = {};
+    this.pingInterval = null;
+    this.reconnectTimeout = null;
+    this.callTimeoutMs = options.callTimeout || CALL_TIMEOUT;
+    this.pingIntervalMs = options.pingInterval || PING_INTERVAL;
+    this.reconnectTimeoutMs = options.reconnectTimeout || RECONNECT_TIMEOUT;
     this.open();
   }
 
@@ -175,12 +178,13 @@ class Metacom extends EventEmitter {
         if (this.opening) await this.opening;
         if (!this.connected) await this.open();
         return new Promise((resolve, reject) => {
-          setTimeout(() => {
+          this.callTimeouts[callId] = setTimeout(() => {
+            delete this.callTimeouts[callId];
             if (this.calls.has(callId)) {
               this.calls.delete(callId);
               reject(new Error('Request timeout'));
             }
-          }, this.callTimeout);
+          }, this.callTimeoutMs);
           this.calls.set(callId, [resolve, reject]);
           const packet = { call: callId, [target]: args };
           this.send(JSON.stringify(packet));
@@ -207,9 +211,11 @@ class WebsocketTransport extends Metacom {
       this.opening = null;
       this.connected = false;
       this.emit('close');
-      setTimeout(() => {
-        if (this.active) this.open();
-      }, this.reconnectTimeout);
+      if (this.active) {
+        this.reconnectTimeout = setTimeout(() => {
+          if (this.active) this.open();
+        }, this.reconnectTimeoutMs);
+      }
     });
 
     socket.addEventListener('error', (err) => {
@@ -217,12 +223,12 @@ class WebsocketTransport extends Metacom {
       socket.close();
     });
 
-    setInterval(() => {
+    this.pingInterval = setInterval(() => {
       if (this.active) {
         const interval = new Date().getTime() - this.lastActivity;
-        if (interval > this.pingInterval) this.send('{}');
+        if (interval > this.pingIntervalMs) this.send('{}');
       }
-    }, this.pingInterval);
+    }, this.pingIntervalMs);
 
     this.opening = new Promise((resolve) => {
       socket.addEventListener('open', () => {
@@ -237,6 +243,12 @@ class WebsocketTransport extends Metacom {
 
   close() {
     this.active = false;
+    clearInterval(this.pingInterval);
+    this.pingInterval = null;
+    for (const callId in this.callTimeouts) {
+      clearTimeout(this.callTimeouts[callId]);
+      delete this.callTimeouts[callId];
+    }
     connections.delete(this);
     if (!this.socket) return;
     this.socket.close();

--- a/test/client.js
+++ b/test/client.js
@@ -1,3 +1,43 @@
 'use strict';
 
-console.log('No client tests implemented');
+const metatests = require('metatests');
+const { delay } = require('metautil');
+const { Server } = require('../lib/server');
+const { Metacom } = require('../lib/client.js');
+
+const host = 'localhost';
+const protocol = 'ws';
+const port = 8000;
+const url = `${protocol}://${host}:${port}`;
+const queue = { size: 1, timeout: 1000 };
+const options = { port, protocol, queue };
+const application = { console };
+
+const CONNECTION_CLOSE_TIMEOUT = 100;
+
+metatests.test('Client.close()', async (test) => {
+  const server = new Server(options, application);
+  const client = Metacom.create(url);
+  await client.open();
+  await client.load();
+
+  test.ok(client.active);
+  test.ok(client.pingInterval);
+  test.notEqual(client.callTimeouts, {});
+
+  client.close();
+
+  await delay(CONNECTION_CLOSE_TIMEOUT);
+
+  test.equal(client.active, false);
+  test.equal(client.connected, false);
+  test.equal(client.socket, null);
+
+  test.equal(client.pingInterval, null);
+  test.equal(client.reconnectTimeout, null);
+  test.equal(client.callTimeouts, {});
+
+  server.close();
+
+  test.end();
+});


### PR DESCRIPTION
This pull request addresses a process exit issue discovered during the testing phase. The problem occurs when the Metacom client's close method is called, but the following intervals and timeouts prevent the Node.js process from exiting successfully:

1. client.pingInterval is infinite
2. client.reconnectTimeout
3. call timeouts

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
