### PR TITLE
Optimize streams

### DIFF
--- a/dist/events.js
+++ b/dist/events.js
@@ -60,6 +60,10 @@ class EventEmitter {
     }
     this.events.delete(name);
   }
+
+  static once(emitter, name) {
+    return new Promise((resolve) => emitter.once(name, resolve));
+  }
 }
 
 export default EventEmitter;

--- a/dist/streams.js
+++ b/dist/streams.js
@@ -3,9 +3,8 @@ import EventEmitter from './events.js';
 const ID_LENGTH = 4;
 
 const chunkEncode = (id, payload) => {
-  const buffer = new ArrayBuffer(ID_LENGTH + payload.length);
-  const view = new DataView(buffer);
-  const chunk = new Uint8Array(buffer);
+  const chunk = new Uint8Array(ID_LENGTH + payload.length);
+  const view = new DataView(chunk.buffer);
   view.setInt32(0, id);
   chunk.set(payload, ID_LENGTH);
   return chunk;

--- a/dist/streams.js
+++ b/dist/streams.js
@@ -61,7 +61,7 @@ class MetaReadable extends EventEmitter {
   }
 
   pipe(writable) {
-    void this.finalize(writable);
+    this.finalize(writable);
     return writable;
   }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -62,6 +62,10 @@ class EventEmitter {
     }
     this.events.delete(name);
   }
+
+  static once(emitter, name) {
+    return new Promise((resolve) => emitter.once(name, resolve));
+  }
 }
 
 module.exports = EventEmitter;

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -64,7 +64,7 @@ class MetaReadable extends EventEmitter {
   }
 
   pipe(writable) {
-    void this.finalize(writable);
+    this.finalize(writable);
     return writable;
   }
 

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -42,7 +42,7 @@ class MetaReadable extends EventEmitter {
   async push(data) {
     if (this.queue.length > this.highWaterMark) {
       this.checkStreamLimits();
-      await this.waitEvent(PULL_EVENT);
+      await EventEmitter.once(this, PULL_EVENT);
       return this.push(data);
     }
     this.queue.push(data);
@@ -51,7 +51,7 @@ class MetaReadable extends EventEmitter {
   }
 
   async finalize(writable) {
-    const waitWritableEvent = this.waitEvent.bind(writable);
+    const waitWritableEvent = EventEmitter.once.bind(writable);
     writable.once('error', () => this.terminate());
     for await (const chunk of this) {
       const needDrain = !writable.write(chunk);
@@ -88,7 +88,7 @@ class MetaReadable extends EventEmitter {
 
   async stop() {
     while (this.bytesRead !== this.size) {
-      await this.waitEvent(PULL_EVENT);
+      await EventEmitter.once(this, PULL_EVENT);
     }
     this.streaming = false;
     this.emit(PUSH_EVENT, null);
@@ -96,7 +96,7 @@ class MetaReadable extends EventEmitter {
 
   async read() {
     if (this.queue.length > 0) return this.pull();
-    const finisher = await this.waitEvent(PUSH_EVENT);
+    const finisher = await EventEmitter.once(this, PUSH_EVENT);
     if (finisher === null) return null;
     return this.pull();
   }
@@ -117,10 +117,6 @@ class MetaReadable extends EventEmitter {
     if (this.highWaterMark > MAX_HIGH_WATER_MARK) {
       throw new Error('Stream overflow occurred');
     }
-  }
-
-  waitEvent(event) {
-    return new Promise((resolve) => this.once(event, resolve));
   }
 
   async *[Symbol.asyncIterator]() {

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -52,7 +52,8 @@ class MetaReadable extends EventEmitter {
 
   async finalize(writable) {
     const waitWritableEvent = EventEmitter.once.bind(writable);
-    writable.once('error', () => this.terminate());
+    const onError = () => this.terminate();
+    writable.once('error', onError);
     for await (const chunk of this) {
       const needDrain = !writable.write(chunk);
       if (needDrain) await waitWritableEvent('drain');
@@ -61,6 +62,7 @@ class MetaReadable extends EventEmitter {
     writable.end();
     await waitWritableEvent('close');
     await this.close();
+    writable.removeListener('error', onError);
   }
 
   pipe(writable) {

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -6,9 +6,8 @@ const { Blob } = require('node:buffer');
 const ID_LENGTH = 4;
 
 const chunkEncode = (id, payload) => {
-  const buffer = new ArrayBuffer(ID_LENGTH + payload.length);
-  const view = new DataView(buffer);
-  const chunk = new Uint8Array(buffer);
+  const chunk = new Uint8Array(ID_LENGTH + payload.length);
+  const view = new DataView(chunk.buffer);
   view.setInt32(0, id);
   chunk.set(payload, ID_LENGTH);
   return chunk;


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
