### PR TITLE
Fix `server.close` with timeouts

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -201,6 +201,7 @@ class Server {
 
       req.on('close', () => {
         client.destroy();
+        this.clients.delete(client);
       });
     });
 
@@ -218,6 +219,7 @@ class Server {
 
       connection.on('close', () => {
         client.destroy();
+        this.clients.delete(client);
       });
     });
 
@@ -394,12 +396,11 @@ class Server {
     this.httpServer.close((err) => {
       if (err) this.console.error(err);
     });
-    if (this.clients.size === 0) {
-      await metautil.delay(SHORT_TIMEOUT);
-      return;
-    }
-    await metautil.delay(this.options.timeouts.stop);
+    if (this.clients.size === 0) return;
     this.closeClients();
+    while (this.clients.size > 0) {
+      await metautil.delay(SHORT_TIMEOUT);
+    }
   }
 }
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
