### PR TITLE
Remove unneeded refs in Client constructor

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -50,7 +50,7 @@ class Client extends EventEmitter {
   #transport;
   #streamId;
 
-  constructor(server, transport) {
+  constructor(transport) {
     super();
     this.#transport = transport;
     this.#streamId = 0;
@@ -191,7 +191,7 @@ class Server {
       if (req.method !== 'POST') this.error(403);
       if (res.writableEnded) return;
 
-      const client = new Client(console, transport);
+      const client = new Client(transport);
       this.clients.add(client);
 
       const data = await metautil.receiveBody(req).catch(() => null);
@@ -209,7 +209,7 @@ class Server {
 
     this.wsServer.on('connection', (connection, req) => {
       const transport = new WsTransport(console, req, connection);
-      const client = new Client(console, transport);
+      const client = new Client(transport);
       this.clients.add(client);
 
       connection.on('message', (data, isBinary) => {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
