### PR TITLE
Server optimizations

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -57,6 +57,7 @@ class Client extends EventEmitter {
     this.#streamId = 0;
     this.ip = transport.ip;
     this.session = null;
+    transport.server.clients.add(this);
     transport.on('close', () => {
       this.destroy();
       transport.server.clients.delete(this);
@@ -191,8 +192,6 @@ class Server {
       if (res.writableEnded) return;
 
       const client = new Client(transport);
-      this.clients.add(client);
-
       const data = await metautil.receiveBody(req).catch(() => null);
 
       if (req.url === '/api') this.message(client, data);
@@ -204,7 +203,6 @@ class Server {
     this.wsServer.on('connection', (connection, req) => {
       const transport = new WsTransport(this, req, connection);
       const client = new Client(transport);
-      this.clients.add(client);
 
       connection.on('message', (data, isBinary) => {
         if (isBinary) this.binary(client, data);

--- a/lib/server.js
+++ b/lib/server.js
@@ -169,13 +169,8 @@ class Server {
     const { options, application, console, balancer } = this;
     const { host, port, protocol, timeouts, nagle = true } = options;
     const proto = protocol === 'http' || balancer ? http : https;
-    this.httpServer = proto.createServer({ ...application.cert });
-
-    if (!nagle) {
-      this.httpServer.on('connection', (socket) => {
-        socket.setNoDelay(true);
-      });
-    }
+    const { cert } = application;
+    this.httpServer = proto.createServer({ ...cert, noDelay: !nagle });
 
     this.httpServer.on('listening', () => {
       console.info(`Listen port ${port}`);

--- a/lib/server.js
+++ b/lib/server.js
@@ -281,33 +281,33 @@ class Server {
 
   async stream(client, packet) {
     const { id, name, size, status } = packet;
-    const stream = client.streams.get(id);
-    if (name && typeof name === 'string' && Number.isSafeInteger(size)) {
-      if (stream) {
-        const error = new Error(`Stream ${name} is already initialized`);
-        client.error(400, { id, error, pass: true });
-      } else {
+    const tag = id + '/' + name;
+    try {
+      const stream = client.streams.get(id);
+      if (status) {
+        if (!stream) throw new Error(`Stream ${tag} is not initialized`);
+        if (status === 'end') await stream.close();
+        if (status === 'terminate') await stream.terminate();
+        client.streams.delete(id);
+        return;
+      }
+      const valid = typeof name === 'string' && Number.isSafeInteger(size);
+      if (!valid) throw new Error('Stream packet structure error');
+      if (stream) throw new Error(`Stream ${tag} is already initialized`);
+      {
         const stream = new MetaReadable({ id, name, size });
         client.streams.set(id, stream);
+        this.console.log(`${client.ip}\tstream ${tag} init`);
       }
-    } else if (!stream) {
-      const error = new Error(`Stream ${id} is not initialized`);
-      client.error(400, { id, error, pass: true });
-    } else if (status === 'end') {
-      await stream.close();
-      client.streams.delete(id);
-    } else if (status === 'terminate') {
-      await stream.terminate();
-      client.streams.delete(id);
-    } else {
-      const error = new Error('Stream packet structure error');
+    } catch (error) {
+      this.console.error(`${client.ip}\tstream ${tag} error`);
       client.error(400, { id, error, pass: true });
     }
   }
 
   binary(client, data) {
+    const { id, payload } = Chunk.decode(data);
     try {
-      const { id, payload } = Chunk.decode(data);
       const upstream = client.streams.get(id);
       if (upstream) {
         upstream.push(payload);
@@ -316,6 +316,7 @@ class Server {
         client.error(400, { id, error, pass: true });
       }
     } catch (error) {
+      this.console.error(`${client.ip}\tstream ${id} error`);
       client.error(400, { id: 0, error });
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -57,6 +57,10 @@ class Client extends EventEmitter {
     this.#streamId = 0;
     this.ip = transport.ip;
     this.session = null;
+    transport.on('close', () => {
+      this.destroy();
+      transport.server.clients.delete(this);
+    });
   }
 
   error(code, options) {
@@ -193,11 +197,6 @@ class Server {
 
       if (req.url === '/api') this.message(client, data);
       else this.request(client, transport, data);
-
-      req.on('close', () => {
-        client.destroy();
-        this.clients.delete(client);
-      });
     });
 
     this.wsServer = new ws.Server({ server: this.httpServer });
@@ -210,11 +209,6 @@ class Server {
       connection.on('message', (data, isBinary) => {
         if (isBinary) this.binary(client, data);
         else this.message(client, data);
-      });
-
-      connection.on('close', () => {
-        client.destroy();
-        this.clients.delete(client);
       });
     });
 

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const http = require('node:http');
+const { EventEmitter } = require('node:events');
 const metautil = require('metautil');
 
 const MIME_TYPES = {
@@ -83,8 +84,9 @@ const LOCATION = 'Path=/; Domain';
 const COOKIE_DELETE = `${TOKEN}=deleted; Expires=${EPOCH}; ${LOCATION}=`;
 const COOKIE_HOST = `Expires=${FUTURE}; ${LOCATION}`;
 
-class Transport {
+class Transport extends EventEmitter {
   constructor(server, req) {
+    super();
     this.server = server;
     this.req = req;
     this.ip = req.socket.remoteAddress;
@@ -115,6 +117,9 @@ class HttpTransport extends Transport {
     super(server, req);
     this.res = res;
     if (req.method === 'OPTIONS') this.options();
+    req.on('close', () => {
+      this.emit('close');
+    });
   }
 
   write(data, httpCode = 200, ext = 'json') {
@@ -172,6 +177,9 @@ class WsTransport extends Transport {
   constructor(server, req, connection) {
     super(server, req);
     this.connection = connection;
+    connection.on('close', () => {
+      this.emit('close');
+    });
   }
 
   write(data) {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
