### PR TITLE
Fix server initialization

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -175,10 +175,9 @@ class Server {
 
   bind() {
     const { options, application, console, balancer } = this;
-    const { host, port, protocol, timeouts, nagle = true } = options;
+    const { host, port, protocol, timeouts, nagle = true, key, cert } = options;
     const proto = protocol === 'http' || balancer ? http : https;
-    const { cert } = application;
-    this.httpServer = proto.createServer({ ...cert, noDelay: !nagle });
+    this.httpServer = proto.createServer({ key, cert, noDelay: !nagle });
 
     this.httpServer.on('listening', () => {
       console.info(`Listen port ${port}`);

--- a/lib/server.js
+++ b/lib/server.js
@@ -215,7 +215,7 @@ class Server {
       });
     });
 
-    this.wsServer.on('error', (err) => {
+    this.httpServer.on('error', (err) => {
       if (err.code !== 'EADDRINUSE') return;
       console.warn(`Address in use: ${host}:${port}, retry...`);
       setTimeout(() => {
@@ -372,6 +372,7 @@ class Server {
   }
 
   async close() {
+    if (!this.httpServer.listening) return;
     this.httpServer.close((err) => {
       if (err) this.console.error(err);
     });


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
