### PR TITLE
Support pipe readable

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -2,6 +2,7 @@
 
 const http = require('node:http');
 const { EventEmitter } = require('node:events');
+const { Readable } = require('node:stream');
 const metautil = require('metautil');
 
 const MIME_TYPES = {
@@ -127,7 +128,8 @@ class HttpTransport extends Transport {
     if (res.writableEnded) return;
     const mimeType = MIME_TYPES[ext] || MIME_TYPES.html;
     res.writeHead(httpCode, { ...HEADERS, 'Content-Type': mimeType });
-    res.end(data);
+    if (data instanceof Readable) data.pipe(res);
+    else res.end(data);
   }
 
   redirect(location) {


### PR DESCRIPTION
- [ ] tests and linter show no problems (`npm t`)
- [ ] code is properly formatted (`npm run fmt`)
