### PR TITLE
Support Content-Range headers and serve file range

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -188,7 +188,7 @@ class Server {
     this.httpServer.on('request', async (req, res) => {
       const transport = new HttpTransport(this, req, res);
       if (!req.url.startsWith('/api')) {
-        application.serveStatic(req.url, transport);
+        application.static.serve(req.url, transport);
         return;
       }
       if (balancer) this.balancing(transport);

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -123,12 +123,19 @@ class HttpTransport extends Transport {
     });
   }
 
-  write(data, httpCode = 200, ext = 'json') {
+  write(data, httpCode = 200, ext = 'json', options = {}) {
     const { res } = this;
     if (res.writableEnded) return;
+    const streaming = data instanceof Readable;
     const mimeType = MIME_TYPES[ext] || MIME_TYPES.html;
-    res.writeHead(httpCode, { ...HEADERS, 'Content-Type': mimeType });
-    if (data instanceof Readable) data.pipe(res);
+    const headers = { ...HEADERS, 'Content-Type': mimeType };
+    if (httpCode === 206) {
+      const { start, end, size = '*' } = options;
+      headers['Content-Range'] = `bytes ${start}-${end}/${size}`;
+    }
+    if (!streaming) headers['Content-Length'] = data.length;
+    res.writeHead(httpCode, headers);
+    if (streaming) data.pipe(res);
     else res.end(data);
   }
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
