### PR TITLE
Move semaphore from metacom to `Application`

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,6 @@ const http = require('node:http');
 const https = require('node:https');
 const { EventEmitter } = require('node:events');
 const metautil = require('metautil');
-const { Semaphore } = metautil;
 const ws = require('ws');
 const { HttpTransport, WsTransport, HEADERS } = require('./transport.js');
 const { MetaReadable, MetaWritable, chunkDecode } = require('./streams.js');
@@ -161,9 +160,6 @@ class Server {
     this.balancer = options.kind === 'balancer';
     this.console = application.console;
     if (options.cors) addHeaders(options.cors);
-    const { queue } = options;
-    const concurrency = queue.concurrency || options.concurrency;
-    this.semaphore = new Semaphore(concurrency, queue.size, queue.timeout);
     this.httpServer = null;
     this.wsServer = null;
     this.clients = new Set();


### PR DESCRIPTION
Closes: https://github.com/metarhia/metacom/issues/449

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
