### PR TITLE
Remove ws from balancer port

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -195,6 +195,13 @@ class Server {
       this.request(client, transport, data);
     });
 
+    if (balancer) {
+      this.httpServer.on('upgrade', (request, socket) => {
+        socket.destroy();
+      });
+      return;
+    }
+
     this.wsServer = new ws.Server({ server: this.httpServer });
 
     this.wsServer.on('connection', (connection, req) => {
@@ -209,8 +216,9 @@ class Server {
   }
 
   listen() {
-    const { console, options } = this;
+    const { console, options, balancer } = this;
     const { host, port, timeouts } = options;
+    const server = balancer ? this.httpServer : this.wsServer;
 
     return new Promise((resolve, reject) => {
       this.httpServer.on('listening', () => {
@@ -218,7 +226,7 @@ class Server {
         resolve(this);
       });
 
-      this.wsServer.on('error', (err) => {
+      server.on('error', (err) => {
         if (err.code !== 'EADDRINUSE') return;
         this.retry--;
         if (this.retry === 0) return void reject(err);


### PR DESCRIPTION
Is it okay that ws work on the balancer port?

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
