### PR TITLE
Proposal: Abortable and timeouts

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -285,6 +285,8 @@ class Server {
     } catch {
       return void client.error(503, { id });
     }
+    if (typeof proc.onAborted === 'function')
+      abortable.once('aborted', proc.onAborted);
     const { timeouts } = this.options;
     if (proc.timeout && proc.timeout < timeouts.request)
       abortable?.resetTimeout(proc.timeout);
@@ -372,6 +374,8 @@ class Server {
     const context = client.createContext();
     const par = { verb, method, args, headers };
     const { timeouts } = this.options;
+    if (typeof proc.onAborted === 'function')
+      abortable.once('aborted', proc.onAborted);
     if (proc.timeout && proc.timeout < timeouts.request)
       abortable?.resetTimeout(proc.timeout);
     let result = null;

--- a/lib/server.js
+++ b/lib/server.js
@@ -276,7 +276,7 @@ class Server {
     client.error(500, { error, pass: true });
   }
 
-  async rpc(client, packet, abortable = null) {
+  async rpc(client, packet) {
     const { id, method, args } = packet;
     const [unitName, methodName] = method.split('/');
     const [unit, ver = '*'] = unitName.split('.');
@@ -291,16 +291,17 @@ class Server {
     } catch {
       return void client.error(503, { id });
     }
-    if (typeof proc.onAborted === 'function')
-      abortable?.once('aborted', proc.onAborted);
     const { timeouts } = this.options;
+    const abortable = getClientAbortable(client);
+    if (typeof proc.onAborted === 'function')
+      abortable.once('aborted', proc.onAborted);
     if (proc.timeout && proc.timeout < timeouts.request)
-      abortable?.resetTimeout(proc.timeout);
+      abortable.resetTimeout(proc.timeout);
     let result = null;
     try {
       result = await proc.invoke(context, args);
     } catch (error) {
-      if (error === abortable?.reason) abortable?.throwIfAborted();
+      if (error === abortable.reason) abortable.throwIfAborted();
       let code = error.code === 'ETIMEOUT' ? 408 : 500;
       if (typeof error.code === 'number') code = error.code;
       error.httpCode = code;
@@ -308,7 +309,7 @@ class Server {
     } finally {
       proc.leave();
     }
-    abortable?.throwIfAborted();
+    abortable.throwIfAborted();
     if (metautil.isError(result)) {
       const { code, httpCode = 200 } = result;
       return void client.error(code, { id, error: result, httpCode });
@@ -375,24 +376,25 @@ class Server {
     else abortable.run(this.rpc.bind(this), client, packet);
   }
 
-  async hook(client, proc, packet, verb, headers, abortable = null) {
+  async hook(client, proc, packet, verb, headers) {
     const { id, method, args } = packet;
     if (!proc) return void client.error(404, { id });
     const context = client.createContext();
     const par = { verb, method, args, headers };
     const { timeouts } = this.options;
+    const abortable = getClientAbortable(client);
     if (typeof proc.onAborted === 'function')
-      abortable?.once('aborted', proc.onAborted);
+      abortable.once('aborted', proc.onAborted);
     if (proc.timeout && proc.timeout < timeouts.request)
-      abortable?.resetTimeout(proc.timeout);
+      abortable.resetTimeout(proc.timeout);
     let result = null;
     try {
       result = await proc.invoke(context, par);
     } catch (error) {
-      if (error === abortable?.reason) abortable?.throwIfAborted();
+      if (error === abortable.reason) abortable.throwIfAborted();
       return void client.error(500, { id, error });
     }
-    abortable?.throwIfAborted();
+    abortable.throwIfAborted();
     client.send(result);
     this.console.log(`${client.ip}\t${method}`);
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -65,12 +65,9 @@ class Client extends EventEmitter {
       this.destroy();
       transport.server.clients.delete(this);
     });
-    const timeoutHandler = () => {
-      if (transport instanceof HttpTransport)
-        transport.off('timeout', timeoutHandler);
+    transport.once('timeout', () => {
       abortable.abort('Request Timeout');
-    };
-    transport.once('timeout', timeoutHandler);
+    });
     abortable.once('aborted', (error) => {
       if (transport instanceof HttpTransport) {
         error.code = error.httpCode = 408;

--- a/lib/server.js
+++ b/lib/server.js
@@ -63,6 +63,11 @@ class Client extends EventEmitter {
       this.destroy();
       transport.server.clients.delete(this);
     });
+    transport.once('timeout', () => {
+      if (transport instanceof HttpTransport) {
+        this.error(408, { error: new Error('Request Timeout') });
+      }
+    });
   }
 
   error(code, options) {
@@ -171,12 +176,13 @@ class Server {
   init() {
     const { application, balancer, options } = this;
     const { protocol, nagle = true, key, cert, SNICallback } = options;
+    const { timeouts } = options;
     const proto = protocol === 'http' || balancer ? http : https;
     const opt = { key, cert, noDelay: !nagle, SNICallback };
     this.httpServer = proto.createServer(opt);
 
     this.httpServer.on('request', async (req, res) => {
-      const transport = new HttpTransport(this, req, res);
+      const transport = new HttpTransport(this, req, res, timeouts.request);
       const api = req.url.startsWith('/api');
       if (!api && !(balancer && req.url === '/')) {
         if (application.static.constructor.name !== 'Static') return;

--- a/lib/server.js
+++ b/lib/server.js
@@ -280,6 +280,9 @@ class Server {
     } catch {
       return void client.error(503, { id });
     }
+    const { timeouts } = this.options;
+    if (proc.timeout && proc.timeout < timeouts.request)
+      abortable?.resetTimeout(proc.timeout);
     let result = null;
     try {
       result = await proc.invoke(context, args);
@@ -362,6 +365,9 @@ class Server {
     if (!proc) return void client.error(404, { id });
     const context = client.createContext();
     const par = { verb, method, args, headers };
+    const { timeouts } = this.options;
+    if (proc.timeout && proc.timeout < timeouts.request)
+      abortable?.resetTimeout(proc.timeout);
     let result = null;
     try {
       result = await proc.invoke(context, par);

--- a/lib/server.js
+++ b/lib/server.js
@@ -71,7 +71,7 @@ class Client extends EventEmitter {
       abortable.abort('Request Timeout');
     };
     transport.once('timeout', timeoutHandler);
-    this.#abortable.once('aborted', (error) => {
+    abortable.once('aborted', (error) => {
       if (transport instanceof HttpTransport) {
         error.code = error.httpCode = 408;
         this.error(error.code, { error });
@@ -151,6 +151,14 @@ class Client extends EventEmitter {
     if (!session) return false;
     this.session = session;
     return true;
+  }
+
+  get aborted() {
+    return this.#abortable.aborted;
+  }
+
+  throwIfAborted() {
+    this.#abortable.throwIfAborted();
   }
 
   close() {
@@ -287,14 +295,15 @@ class Server {
     try {
       result = await proc.invoke(context, args);
     } catch (error) {
+      if (error === abortable?.reason) abortable?.throwIfAborted();
       let code = error.code === 'ETIMEOUT' ? 408 : 500;
       if (typeof error.code === 'number') code = error.code;
       error.httpCode = code;
       return void client.error(code, { id, error });
     } finally {
       proc.leave();
-      abortable?.throwIfAborted();
     }
+    abortable?.throwIfAborted();
     if (metautil.isError(result)) {
       const { code, httpCode = 200 } = result;
       return void client.error(code, { id, error: result, httpCode });
@@ -372,10 +381,10 @@ class Server {
     try {
       result = await proc.invoke(context, par);
     } catch (error) {
+      if (error === abortable?.reason) abortable?.throwIfAborted();
       return void client.error(500, { id, error });
-    } finally {
-      abortable?.throwIfAborted();
     }
+    abortable?.throwIfAborted();
     client.send(result);
     this.console.log(`${client.ip}\t${method}`);
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -361,14 +361,16 @@ class Server {
     const { id, method, args } = packet;
     if (!proc) return void client.error(404, { id });
     const context = client.createContext();
+    const par = { verb, method, args, headers };
+    let result = null;
     try {
-      const par = { verb, method, args, headers };
-      const result = await proc.invoke(context, par);
-      client.send(result);
+      result = await proc.invoke(context, par);
     } catch (error) {
-      client.error(500, { id, error });
+      return void client.error(500, { id, error });
+    } finally {
+      abortable?.throwIfAborted();
     }
-    abortable?.throwIfAborted();
+    client.send(result);
     this.console.log(`${client.ip}\t${method}`);
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -47,6 +47,7 @@ class Context {
   }
 }
 
+let getClientAbortable = null;
 class Client extends EventEmitter {
   #transport;
   #abortable;
@@ -74,6 +75,10 @@ class Client extends EventEmitter {
         this.error(error.code, { error });
       }
     });
+  }
+
+  static {
+    getClientAbortable = (client) => client.#abortable;
   }
 
   error(code, options) {
@@ -211,10 +216,10 @@ class Server {
 
       if (req.url === '/api') {
         if (req.method !== 'POST') transport.error(403);
-        else this.message(client, abortable, data);
+        else this.message(client, data);
         return;
       }
-      this.request(client, transport, abortable, data);
+      this.request(client, transport, data);
     });
 
     if (balancer) return;
@@ -227,7 +232,7 @@ class Server {
 
       connection.on('message', (data, isBinary) => {
         if (isBinary) this.binary(client, new Uint8Array(data));
-        else this.message(client, abortable, data);
+        else this.message(client, data);
       });
     });
   }
@@ -257,15 +262,16 @@ class Server {
     });
   }
 
-  message(client, abortable, data) {
+  message(client, data) {
     if (Buffer.compare(EMPTY_PACKET, data) === 0) {
       return void client.send('{}');
     }
     const packet = metautil.jsonParse(data) || {};
     const { id, type, method } = packet;
-    if (type === 'call' && id && method)
+    if (type === 'call' && id && method) {
+      const abortable = getClientAbortable(client);
       return void abortable.run(this.rpc.bind(this), client, packet);
-    else if (type === 'stream' && id) return void this.stream(client, packet);
+    } else if (type === 'stream' && id) return void this.stream(client, packet);
     const error = new Error('Packet structure error');
     client.error(500, { error, pass: true });
   }
@@ -352,7 +358,7 @@ class Server {
     }
   }
 
-  request(client, transport, abortable, data) {
+  request(client, transport, data) {
     const { application } = this;
     const { headers, url, method: verb } = transport.req;
     const pathname = url.slice('/api/'.length);
@@ -363,6 +369,7 @@ class Server {
     const args = { ...parameters, ...body };
     const packet = { id: 0, method: unit + '/' + method, args };
     const hook = application.getHook(unit);
+    const abortable = getClientAbortable(client);
     if (hook)
       abortable.run(this.hook.bind(this), client, hook, packet, verb, headers);
     else abortable.run(this.rpc.bind(this), client, packet);

--- a/lib/server.js
+++ b/lib/server.js
@@ -286,7 +286,7 @@ class Server {
       return void client.error(503, { id });
     }
     if (typeof proc.onAborted === 'function')
-      abortable.once('aborted', proc.onAborted);
+      abortable?.once('aborted', proc.onAborted);
     const { timeouts } = this.options;
     if (proc.timeout && proc.timeout < timeouts.request)
       abortable?.resetTimeout(proc.timeout);
@@ -375,7 +375,7 @@ class Server {
     const par = { verb, method, args, headers };
     const { timeouts } = this.options;
     if (typeof proc.onAborted === 'function')
-      abortable.once('aborted', proc.onAborted);
+      abortable?.once('aborted', proc.onAborted);
     if (proc.timeout && proc.timeout < timeouts.request)
       abortable?.resetTimeout(proc.timeout);
     let result = null;

--- a/lib/server.js
+++ b/lib/server.js
@@ -49,11 +49,13 @@ class Context {
 
 class Client extends EventEmitter {
   #transport;
+  #abortable;
   #streamId;
 
-  constructor(transport) {
+  constructor(transport, abortable) {
     super();
     this.#transport = transport;
+    this.#abortable = abortable;
     this.#streamId = 0;
     this.ip = transport.ip;
     this.session = null;
@@ -66,6 +68,12 @@ class Client extends EventEmitter {
     transport.once('timeout', () => {
       if (transport instanceof HttpTransport) {
         this.error(408, { error: new Error('Request Timeout') });
+      }
+    });
+    this.#abortable.once('aborted', (error) => {
+      if (transport instanceof HttpTransport) {
+        error.code = error.httpCode = 408;
+        this.error(error.code, { error });
       }
     });
   }
@@ -191,12 +199,13 @@ class Server {
       if (balancer) this.balancing(transport);
       if (res.writableEnded) return;
 
-      const client = new Client(transport);
+      const abortable = new metautil.Abortable();
+      const client = new Client(transport, abortable);
       const data = await metautil.receiveBody(req).catch(() => null);
 
       if (req.url === '/api') {
         if (req.method !== 'POST') transport.error(403);
-        else this.message(client, data);
+        else this.message(client, abortable, data);
         return;
       }
       this.request(client, transport, data);
@@ -207,11 +216,12 @@ class Server {
 
     this.wsServer.on('connection', (connection, req) => {
       const transport = new WsTransport(this, req, connection);
-      const client = new Client(transport);
+      const abortable = new metautil.Abortable();
+      const client = new Client(transport, abortable);
 
       connection.on('message', (data, isBinary) => {
         if (isBinary) this.binary(client, new Uint8Array(data));
-        else this.message(client, data);
+        else this.message(client, abortable, data);
       });
     });
   }
@@ -241,19 +251,20 @@ class Server {
     });
   }
 
-  message(client, data) {
+  message(client, abortable, data) {
     if (Buffer.compare(EMPTY_PACKET, data) === 0) {
       return void client.send('{}');
     }
     const packet = metautil.jsonParse(data) || {};
     const { id, type, method } = packet;
-    if (type === 'call' && id && method) return void this.rpc(client, packet);
+    if (type === 'call' && id && method)
+      return void abortable.run(this.rpc.bind(this), client, packet);
     else if (type === 'stream' && id) return void this.stream(client, packet);
     const error = new Error('Packet structure error');
     client.error(500, { error, pass: true });
   }
 
-  async rpc(client, packet) {
+  async rpc(client, packet, abortable = null) {
     const { id, method, args } = packet;
     const [unitName, methodName] = method.split('/');
     const [unit, ver = '*'] = unitName.split('.');
@@ -278,6 +289,7 @@ class Server {
       return void client.error(code, { id, error });
     } finally {
       proc.leave();
+      abortable?.throwIfAborted();
     }
     if (metautil.isError(result)) {
       const { code, httpCode = 200 } = result;

--- a/lib/server.js
+++ b/lib/server.js
@@ -209,7 +209,7 @@ class Server {
         else this.message(client, abortable, data);
         return;
       }
-      this.request(client, transport, data);
+      this.request(client, transport, abortable, data);
     });
 
     if (balancer) return;
@@ -341,7 +341,7 @@ class Server {
     }
   }
 
-  request(client, transport, data) {
+  request(client, transport, abortable, data) {
     const { application } = this;
     const { headers, url, method: verb } = transport.req;
     const pathname = url.slice('/api/'.length);
@@ -352,11 +352,12 @@ class Server {
     const args = { ...parameters, ...body };
     const packet = { id: 0, method: unit + '/' + method, args };
     const hook = application.getHook(unit);
-    if (hook) this.hook(client, hook, packet, verb, headers);
-    else this.rpc(client, packet);
+    if (hook)
+      abortable.run(this.hook.bind(this), client, hook, packet, verb, headers);
+    else abortable.run(this.rpc.bind(this), client, packet);
   }
 
-  async hook(client, proc, packet, verb, headers) {
+  async hook(client, proc, packet, verb, headers, abortable = null) {
     const { id, method, args } = packet;
     if (!proc) return void client.error(404, { id });
     const context = client.createContext();
@@ -367,6 +368,7 @@ class Server {
     } catch (error) {
       client.error(500, { id, error });
     }
+    abortable?.throwIfAborted();
     this.console.log(`${client.ip}\t${method}`);
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -65,11 +65,12 @@ class Client extends EventEmitter {
       this.destroy();
       transport.server.clients.delete(this);
     });
-    transport.once('timeout', () => {
-      if (transport instanceof HttpTransport) {
-        this.error(408, { error: new Error('Request Timeout') });
-      }
-    });
+    const timeoutHandler = () => {
+      if (transport instanceof HttpTransport)
+        transport.off('timeout', timeoutHandler);
+      abortable.abort('Request Timeout');
+    };
+    transport.once('timeout', timeoutHandler);
     this.#abortable.once('aborted', (error) => {
       if (transport instanceof HttpTransport) {
         error.code = error.httpCode = 408;

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -123,13 +123,14 @@ class Transport extends EventEmitter {
 }
 
 class HttpTransport extends Transport {
-  constructor(server, req, res) {
+  constructor(server, req, res, timeout = 0) {
     super(server, req);
     this.res = res;
     if (req.method === 'OPTIONS') this.options();
     req.on('close', () => {
       this.emit('close');
     });
+    res.setTimeout(timeout, () => this.emit('timeout'));
   }
 
   write(data, httpCode = 200, ext = 'json', options = {}) {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

This is a proposal to use the Abortable class proposed in metarhia/metautil#198 to manage any kind of abortable tasks.

Currently:
1. There's only one way to abort user defined APIs by optionally setting timeout for method;
2. There's no way to check if user API is aborted by timeout in the middle of user code execution;
3. There's a request timeout in application/config/server.js that can be used for transport-level timeouts:
```js
...
  timeouts: {
    ...
    request: 5000,
    ...
  },
...
```
Abortable can:
1. Perform a manual task abortion by explicitly calling `abort()` method;
3. Perform task abortion on timeout;
4. The `resetTimeout()` method can reset the scheduled timeout to a different value when the task is already running.
We can also check if the task is aborted by calling `aborted` getter and throw by `throwIfAborted()`

This implementation utilizes `timeouts.request` from application/config/server.js to create transport-level timeouts (currently only `HttpTransport`) and also `timeout` that is optionally defined on user API endpoint. Abortable is created on user request and injected into `Client` as private member. The `aborted` and `throwIfAborted()` are public in `Client` so they can be used on endpoint to check if the task is aborted and stop execution. Additionally, `onAborted` handler can be implemented by the user.

Here's an example:
```js
({
  access: 'public',

  parameters: {
    a: 'number',
    b: 'number',
  },

  timeout: 150,

  method: async ({ a, b }) => {
    const result = a + b;
    await node.timers.promises.setTimeout(200);
    console.log(context.client.aborted); // true
    context.client.throwIfAborted();
    /* this line will never be reached,
    the execution will be aborted with request timeout (408)
    */
    console.log(context.client.aborted);
    await node.timers.promises.setTimeout(6000);
    console.log(context.client.aborted);
    context.client.throwIfAborted();
    return result;
  },

  onAborted: (reason) => {
    console.log(`Aborted! ${reason}`);
  },

  returns: 'number',
});

```
This will be aborted as well by `Server.rpc()` (`timeouts.request = 5000`):
```js
({
  access: 'public',

  parameters: {
    a: 'number',
    b: 'number',
  },

  method: async ({ a, b }) => {
    const result = a + b;
    await node.timers.promises.setTimeout(6000);
    console.log(context.client.aborted);
    return result;
  },

  onAborted: (reason) => {
    console.log(`Aborted! ${reason}`);
  },

  returns: 'number',
});

```
