### PR TITLE
Fix conversion of a thrown exceptions with unknown error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Fix conversion of custom thrown exceptions for response to client
+
 ## [3.2.0][] - 2023-12-10
 
 - Remove `EventEmitter` polyfill, use polyfill from metautil 5.0.0

--- a/lib/server.js
+++ b/lib/server.js
@@ -268,7 +268,7 @@ class Server {
     } catch (error) {
       let code = error.code === 'ETIMEOUT' ? 408 : 500;
       if (typeof error.code === 'number') code = error.code;
-      error.httpCode = code;
+      error.httpCode = code < 600 ? code : 500;
       return void client.error(code, { id, error });
     } finally {
       proc.leave();

--- a/lib/server.js
+++ b/lib/server.js
@@ -268,7 +268,7 @@ class Server {
     } catch (error) {
       let code = error.code === 'ETIMEOUT' ? 408 : 500;
       if (typeof error.code === 'number') code = error.code;
-      error.httpCode = code < 600 ? code : 500;
+      error.httpCode = code <= 599 ? code : 500;
       return void client.error(code, { id, error });
     } finally {
       proc.leave();

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -103,7 +103,8 @@ class Transport extends EventEmitter {
     const message = pass && error ? error.message : status || 'Unknown error';
     const reason = `${httpCode}\t${code}\t${error ? error.stack : status}`;
     console.error(`${ip}\t${method}\t${url}\t${reason}`);
-    const packet = { type: 'callback', id, error: { message, code } };
+    const outCode = pass ? code : httpCode;
+    const packet = { type: 'callback', id, error: { message, code: outCode } };
     this.send(packet, httpCode);
   }
 


### PR DESCRIPTION
Notice: custom exceptions with error code less then 500 still be passed as is (neither code not message won't be converted). The basis of the decision — potential necessity to imitate client error responses (400-499).

As a result of this PR:
```js
// Code
throw new Error('Custom exception', 12345);

// Return message
{"type":"callback","id":5,"error":{"message":"Internal Server Error","code":500}}

// Server log distinguishes codes
21:13:35  W2   error   127.0.0.1	GET	/api	500	12345	Error: Custom exception
```

HOWEVER

```js
// Code
throw new Error('Custom exception', 404);

// Return message contains error text without replacement by known reason phrases of status codes
{"type":"callback","id":4,"error":{"message":"Custom exception","code":404}}

// Server log
21:12:18  W2   error   127.0.0.1	GET	/api	404	404	Error: Custom exception
```

Closes: https://github.com/metarhia/metacom/issues/485

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
