### PR TITLE
Refactor ping packet handling in WebsocketTransport

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -7,7 +7,7 @@ const { MetaWritable, MetaReadable, chunkDecode } = require('./streams.js');
 const CALL_TIMEOUT = 7 * 1000;
 const PING_INTERVAL = 60 * 1000;
 const RECONNECT_TIMEOUT = 2 * 1000;
-const PING_PACKET = Buffer.from('{}');
+const PING_PACKET = {};
 
 const connections = new Set();
 
@@ -216,7 +216,7 @@ class WebsocketTransport extends Metacom {
     this.ping = setInterval(() => {
       if (this.active) {
         const interval = Date.now() - this.lastActivity;
-        if (interval > this.pingInterval) this.write(PING_PACKET);
+        if (interval > this.pingInterval) this.send(PING_PACKET);
       }
     }, this.pingInterval);
 


### PR DESCRIPTION
Server-server connection ping error
<img width="667" alt="Снимок экрана 2024-12-04 в 16 06 48" src="https://github.com/user-attachments/assets/5b2fe798-99d6-4e9a-b7fa-e41c22372fb9">


- Changed PING_PACKET from a Buffer to an object for improved clarity.
- Updated the method call from `this.write(PING_PACKET)` to `this.send(PING_PACKET)` to reflect the new structure.

This change enhances the readability and maintainability of the code related to pinging in the WebSocket transport layer.

<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [ +] tests and linter show no problems (`npm t`)
- [+ ] tests are added/updated for bug fixes and new features
- [+ ] code is properly formatted (`npm run fix`)
- [+ ] description of changes is added in CHANGELOG.md
- [ +] update .d.ts typings
